### PR TITLE
fix: use URL filename when `content-disposition` header is `attachment` but no filename is specified

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn download_file<'a>(urls: Vec<String>, browser_type: Option<BrowserType>) -> Re
 
         let disparsed = parse_content_disposition(disposition);
         let output_filename = if disparsed.disposition == DispositionType::Attachment {
-            disparsed.filename_full().unwrap()
+            disparsed.filename_full().unwrap_or(url_filename.to_string())
         } else {
             url_filename.to_string()
         };


### PR DESCRIPTION
Fixes a panic if the server replies with a `content-disposition` header that specifies `attachment` but does not specify a filename. This is [allowed by the spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Disposition#syntax), though unusual in my experience.

An example of this behavior was seen when downloading the [gcloud cli](https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz):

```
HTTP/2 200
accept-ranges: bytes
content-disposition: attachment
content-security-policy: default-src 'none'
server: downloads
```

The obvious solution is to use the detected filename from the URL instead. There is still the possibility that a URL without a filename could provide a `content-disposition` header also without a filename, at which point we would fail to download the file.

Possible solutions to that circumstance would be:

1. Prompt the user for a filename
2. Generate a random filename plus an extension determined from the MIME type
3. Generate a filename based on the last directory part plus an extension determined from the MIME type

The third option seems the most reasonable.