### PR TITLE
chore: Rename the crate so that we can publish to crates.io some day

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "rustdl"
 version = "0.4.0"
 edition = "2024"
+description = "An uncomplicated 'download this URL' tool for the command-line."
+repository = "https://github.com/danudey/rust-downloader"
+readme = "README.md"
+license = "MIT"
+keywords = ["command-line", "file-download"]
+categories = [ "command-line-utilities"]
 
 [profile.release-size]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
-# rust-downloader
+# rustdl
 
 A simple rust-written downloading program featuring multithreaded concurrent downloads and progress bars
 
 This is a from-scratch reimplementation of my [python-downloader](https://github.com/danudey/python-downloader) code,
 which itself is derived from the Rich project's [example downloader code](https://github.com/Textualize/rich/blob/master/examples/downloader.py).
 
+The binary for `rustdl` is called `download`.
+
 ## Assumptions
 
 1. That the URL you have provided contains a filename after the final /, or that the webserver provides a Content-Disposition header of type 'attachment' with a filename provided.
 2. That you're okay overwriting that file in the current directory
 3. That no matter how many URLs you provide, you're fine with downloading them all at once concurrently
+
+## Browser support
+
+Currently, `rustdl` supports pulling cookies from several browsers, most notably Firefox and any Chromium variant it can find. Because I'm lazy I've hard-coded `firefox` as the default option because that's what I use. You can pass `--browser` to the tool to tell it which browser to try to fetch cookies from; Safari and Edge are sadly untested at this point in time.
+
+Currently there's no way to do the following (yet):
+
+1. Specify a different browser as default
+2. Specify a different order to auto-detect browsers
+3. Tell it not to use a browser's cookies at all
+
+## Platform support
+
+It's entirely possible that this works on Windows?


### PR DESCRIPTION
Switch to a cleaner, more recognizable name in preparation for, some day, publishing this mess to crates.io.
